### PR TITLE
翻訳機能の実装

### DIFF
--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -1,9 +1,13 @@
-import openai
-import os
+from gpt_utils import call_gpt, translation_prompt
+
 
 def summarize_paper_in_url(url):
-    OpenAI_api_key = os.environ["OPENAI_API_KEY"]
+    pass
 
-    client = openai.OpenAI(api_key=OpenAI_api_key)
 
-    return "Result message"
+def translate_title_tldr_abs(title, tldr, abs):
+    def translate(en):
+        prompt_en = translation_prompt(en)
+        return call_gpt(prompt_en)
+
+    return translate(title), translate(tldr), translate(abs)

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -1,0 +1,40 @@
+import os
+
+from openai import OpenAI
+
+
+def get_client() -> OpenAI:
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY_KUMA"))
+    return client
+
+
+def create_request(prompt):
+    return {
+        "model": "gpt-4-turbo",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant and have a plenty of knowledge about informatics.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0,
+        # "timeout": 15,
+    }
+
+
+def translation_prompt(en):
+    return f"日本語に翻訳してください:\n{en}"
+
+
+def summarize_pdf(pdf_url):
+    # TODO: implement
+    pass
+
+
+def call_gpt(prompt):
+    client = get_client()
+    res = client.chat.completions.create(**create_request(prompt))
+    tokens = res.usage.total_tokens
+    print(f"total tokens: {tokens}")
+    return res.choices[0].message.content  # , tokens

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from re import compile
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
+import gpt_read
 import semantic_utils
 
 # from gpt_read import summarize_paper_in_url
@@ -41,10 +42,13 @@ def handle_message_events(body):
             print("got url: " + url)
 
     if url != "":
-        title, tldr, abstract = semantic_utils.title_tldr_and_abstract(url)
-        message = "タイトル: " + title + "\n"
-        message += "TL;DR: " + tldr + "\n"
-        message += "概要: " + abstract
+        print("start translation")
+        data_en = semantic_utils.title_tldr_and_abstract(url)
+        # title_en = info_en[0]
+        title_ja, tldr_ja, abstract_ja = gpt_read.translate_title_tldr_abs(*data_en)
+        message = "タイトル: " + title_ja + "\n"
+        message += "TL;DR: " + tldr_ja + "\n"
+        message += "概要: " + abstract_ja
         app.client.chat_postMessage(text=message, channel=channel)
 
 


### PR DESCRIPTION
# 翻訳機能の実装
## TL;DR
タイトル、TL;DR、アブストラクトの翻訳機能を追加しました。

## 概要
タイトル、TL;DR、アブストラクトを英文のまま投稿していましたが、#1 の取っ掛かりとしてGPT-4-turboに翻訳させた日本語で投稿されるようになりました。

## 変更点
- `gpt_utils.py` の作成
  -  `call_gpt` 関数で GPT-4-turbo に入力を投げることができます
    - 一応利用トークン数を表示するようにさせています
  - 英日翻訳のためのプロンプトは `translation_prompt` 関数で作れます
  - pdf を要約する `summarize_pdf` 関数の形だけ用意しました
- `gpt_read.py` の追記
  - `translate_title_tldr_abs` 関数でタイトル、TL;DR、アブストラクトを翻訳したものを返すようにしました
    - 雛型重視で `translate_title_tldr_abs` 関数を実装しましたが、正直 `translate` 関数 (ローカル関数) だけで OK なはずです
- `main.py` の修正
  - 翻訳を挟むようにした以外、大枠は同じです

### 変更に伴うお願い
- **環境変数 `OPENAI_API_KEY_KUMA` に GPT の API キーを設定しておいてください**
  - 既に `OPENAI_API_KEY` の環境変数 (今回のとは別) があるので……
- 動かすたびに (ちょっとだけ) お金がかかるので気を付けてください

## これからやること
- タイムアウトの設定
  - GPTはたまに返事をしてくれないので、一定時間返事がなかったらリトライしたい
- 返答を早くする
  - 入力文を分割して非同期処理すればよさそう
- 要約機能の実装
  - ↑ 2つが優先度高めなのでまだまだ先になりそう