### PR TITLE
非同期に翻訳するように変更

### DIFF
--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -1,13 +1,62 @@
-from gpt_utils import call_gpt, translation_prompt
+import asyncio
+
+from gpt_utils import call_gpt_async, create_asyncClient, translation_prompt
 
 
 def summarize_paper_in_url(url):
     pass
 
 
-def translate_title_tldr_abs(title, tldr, abs):
-    def translate(en):
-        prompt_en = translation_prompt(en)
-        return call_gpt(prompt_en)
+def split_en(en: str) -> list[str]:
+    def should_split(li_word: list[str]) -> list[bool]:
+        """
+        Return list of bool, where an index represents whether to sum up the word at that index.
 
-    return translate(title), translate(tldr), translate(abs)
+        :param li_word: list of str
+        :return: list of bool
+        """
+        while len(li_word) > 0 and li_word[-1] == "":
+            li_word.pop(-1)
+
+        li_bool = [False] * len(li_word)
+
+        for i, word in enumerate(li_word):
+            # if word is end of list, then True
+            if i == len(li_word) - 1:
+                li_bool[i] = True
+            # if the next word starts with a capital letter...
+            elif li_word[i + 1][0].isupper():
+                # if word ends with [".", "!", "?"], then True
+                if word.endswith(".") or word.endswith("!") or word.endswith("?"):
+                    li_bool[i] = True
+        return li_bool
+
+    li_word = en.split()
+    li_bool = should_split(li_word)
+    li_sentence = []
+    sentence = ""
+    for word, flag in zip(li_word, li_bool):
+        if flag:
+            sentence += word
+            li_sentence.append(sentence)
+            sentence = ""
+        else:
+            sentence += word + " "
+    return li_sentence
+
+
+async def translate_tpl_en_async(*tpl_en: str) -> list[str]:
+    async def translate_async(en: str) -> str:
+        client = create_asyncClient()
+        li_en = split_en(en)
+        li_prompt = [translation_prompt(en) for en in li_en]
+        tasks = [asyncio.create_task(call_gpt_async(client, prompt)) for prompt in li_prompt]
+        res = await asyncio.gather(*tasks)
+        li_ja, li_tokens = zip(*res)
+        print(f"Total tokens: {sum(li_tokens)}")
+        return "".join(li_ja)
+
+    tasks = [asyncio.create_task(translate_async(en)) for en in tpl_en]
+    res = await asyncio.gather(*tasks)
+    res = [r for r in res]
+    return ["".join(r) for r in res]

--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -58,5 +58,4 @@ async def translate_tpl_en_async(*tpl_en: str) -> list[str]:
 
     tasks = [asyncio.create_task(translate_async(en)) for en in tpl_en]
     res = await asyncio.gather(*tasks)
-    res = [r for r in res]
     return ["".join(r) for r in res]

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -1,10 +1,10 @@
 import os
 
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 
-def get_client() -> OpenAI:
-    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY_KUMA"))
+def create_asyncClient() -> AsyncOpenAI:
+    client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY_KUMA"), timeout=15, max_retries=3)
     return client
 
 
@@ -19,7 +19,6 @@ def create_request(prompt):
             {"role": "user", "content": prompt},
         ],
         "temperature": 0,
-        # "timeout": 15,
     }
 
 
@@ -32,9 +31,11 @@ def summarize_pdf(pdf_url):
     pass
 
 
-def call_gpt(prompt):
-    client = get_client()
-    res = client.chat.completions.create(**create_request(prompt))
-    tokens = res.usage.total_tokens
-    print(f"total tokens: {tokens}")
-    return res.choices[0].message.content  # , tokens
+async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
+    try:
+        res = await client.chat.completions.create(**create_request(prompt))
+        tokens = res.usage.total_tokens
+        return res.choices[0].message.content, tokens
+    except BaseException as e:
+        print(f"{e.__class__.__name__}: {e}")
+        raise e

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from re import compile
 
@@ -40,11 +41,11 @@ def handle_message_events(body):
             print("got url: " + url)
 
     if url != "":
-        print("start translation")
+        print("URL detected.")
         data_en = semantic_utils.paper_informations(url)
-        # title_en = info_en[0]
+        # title_en = data_en["title"]
         title_tldr_abs_en = data_en["title"], data_en["tldr"]["text"], data_en["abstract"]
-        title_ja, tldr_ja, abstract_ja = gpt_read.translate_title_tldr_abs(*title_tldr_abs_en)
+        title_ja, tldr_ja, abstract_ja = asyncio.run(gpt_read.translate_tpl_en_async(*title_tldr_abs_en))
         message = "*タイトル*: " + title_ja + "\n"
         message += "*TL;DR*: " + tldr_ja + "\n"
         message += "*概要*: " + abstract_ja


### PR DESCRIPTION
# 非同期に翻訳するように変更
## TL;DR
翻訳が早くなりました。

## 経緯・概要
#5 で取り急ぎ翻訳機能を実装しましたが、ナイーブに一度に全文を入力していたため時間がかかっていました (40 秒弱かかってた) 。
入力長の長さが問題だったので、文単位に分けることにしました。

タイトル、TL;DR、アブストラクトをそれぞれ文単位に区切って並列に翻訳リクエストを送ることで、ある程度早くなりました (40s → 7s) 。
(たぶん) 旧 Kuma Bot ほど早くはないですが、GPT を使う以上これよりは早くできないと思います。

## 変更点
- `gpt_utils.py` の変更
  - `get_client` 関数を `create_client` 関数にリネームし、戻り値も非同期処理に対応したクライアント ( `AsyncOpenAI` ) に変更
    - ついでに15秒でタイムアウトするように設定
    - リトライは3回まで
  - `call_gpt` 関数を `call_gpt_async` 関数として非同期化
    - ついでにエラーログも出すようにしました
- `gpt_read.py` の変更
  - 英文を文単位に区切る `split_en` 関数を実装
    - ローカル関数の `should_split` 関数は読みづらい気がしたので若干コメント付けてます
  - `translate_title_tldr_abs` 関数を `translate_tpl_en_async` 関数として非同期化
    - 複数の英文を受け取って、それぞれの訳文をリストとして返します
    - ローカル関数の `translate_async` 関数は `translate_tpl_en_async` 関数の引数が1つのバージョンです
    - 正直、非同期処理なんもわからんのでコメント付けてません
- `main.py` の変更
  - 非同期処理実行のために `asyncio` を追加で `import`
  - URL を検知したときの文言を変更

### 変更に伴うお願い
特になし

## これからやること
- 翻訳関連のタスクは完了な気がする
  - 細かいエラーハンドリングは諸説ある
- ついに要約に手を付けるときが来たっぽい

## 備考
プルリクを試験的に全員に送ってみました。

プルリクの書き方や、コードの修正箇所などにツッコミがあればコメントお願いします。
特に無ければなんかリアクションしてください。