### PR TITLE
メッセージの見た目改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
 # Slack Bot to Summarize Paper from URL
-1. slackに投げられたメッセージからurlを抽出
-2. urlをchatGPTに投げて、出力をbotが返信
 
 # How to Run Bot
 * 各環境変数(SLACK_APP_TOKEN,SLACK_BOT_TOKEN)にbotのapi tokenを設定しておく
 * main.pyを走らせている間、研究室内のbotが動く(botは#b4_2023に導入済み)
 
 # What to Do
-* urlをchatGPTに投げて反応を得る
+* urlをchatGPTに投げて反応を得る (almost done)
   * semantic scholarから、引用数、査読済みなどの情報を取ってくる 
 * みんなが興味がありそうな論文を定期的にレコメンドする
-
-# Libraries
-pip install -r requirements.txt
 
 # Setting up virtual environment
 1. `poetry` , `pyenv` を(頑張って)インストールする

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Slack Bot to Summarize Paper from URL
 
-# How to Run Bot
+## How to Run Bot
 * 各環境変数(SLACK_APP_TOKEN,SLACK_BOT_TOKEN)にbotのapi tokenを設定しておく
 * main.pyを走らせている間、研究室内のbotが動く(botは#b4_2023に導入済み)
 
-# What to Do
-* urlをchatGPTに投げて反応を得る (almost done)
+## What to Do
+* urlをchatGPTに投げて反応を得る
   * semantic scholarから、引用数、査読済みなどの情報を取ってくる 
 * みんなが興味がありそうな論文を定期的にレコメンドする
 
-# Setting up virtual environment
+## Setting up virtual environment
 1. `poetry` , `pyenv` を(頑張って)インストールする
 2. このリポジトリを `git clone` する
 4. `pyenv install 3.10.11` する

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,6 @@ def handle_message_events(body):
 
         # post message
         app.client.chat_postMessage(
-            attachments=[{"pretext": "", "text": "source: " + url}],
             blocks=[
                 {"type": "header", "text": {"type": "plain_text", "text": data_en["title"]}},
                 {
@@ -75,7 +74,22 @@ def handle_message_events(body):
                         {"type": "mrkdwn", "text": ":black_nib: *Cited by*: " + str(cites)},
                     ],
                 },
-                {"type": "section", "text": {"text": message, "type": "mrkdwn"}},
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {"type": "text", "text": "論文名: ", "style": {"bold": True}},
+                                {"type": "link", "url": url, "text": title_ja},
+                                {"type": "text", "text": "\nTL;DR: ", "style": {"bold": True}},
+                                {"type": "text", "text": tldr_ja},
+                                {"type": "text", "text": "\n概要: ", "style": {"bold": True}},
+                                {"type": "text", "text": abstract_ja},
+                            ],
+                        }
+                    ],
+                },
             ],
             text=message,
             channel=channel,

--- a/src/main.py
+++ b/src/main.py
@@ -80,7 +80,7 @@ def handle_message_events(body):
                         {
                             "type": "rich_text_section",
                             "elements": [
-                                {"type": "text", "text": "論文名: ", "style": {"bold": True}},
+                                {"type": "text", "text": "タイトル: ", "style": {"bold": True}},
                                 {"type": "link", "url": url, "text": title_ja},
                                 {"type": "text", "text": "\nTL;DR: ", "style": {"bold": True}},
                                 {"type": "text", "text": tldr_ja},

--- a/src/main.py
+++ b/src/main.py
@@ -64,14 +64,15 @@ def handle_message_events(body):
 
         # post message
         app.client.chat_postMessage(
+            attachments=[{"pretext": "", "text": "source: " + url}],
             blocks=[
                 {"type": "header", "text": {"type": "plain_text", "text": data_en["title"]}},
                 {
                     "type": "context",
                     "elements": [
-                        {"type": "mrkdwn", "text": "*Author*: " + authors},
-                        {"type": "mrkdwn", "text": "*Venue*: " + venue + " " + str(year)},
-                        {"type": "mrkdwn", "text": "*Cited by*: " + str(cites)},
+                        {"type": "mrkdwn", "text": ":student: *Author*: " + authors},
+                        {"type": "mrkdwn", "text": ":pushpin: *Venue*: " + venue + " " + str(year)},
+                        {"type": "mrkdwn", "text": ":black_nib: *Cited by*: " + str(cites)},
                     ],
                 },
                 {"type": "section", "text": {"text": message, "type": "mrkdwn"}},

--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,7 @@ def handle_message_events(body):
         )
         # title_en = info_en[0]
         title_tldr_abs_en = data_en["title"], data_en["tldr"]["text"], data_en["abstract"]
+        # title_ja, tldr_ja, abstract_ja = title_tldr_abs_en
         title_ja, tldr_ja, abstract_ja = gpt_read.translate_title_tldr_abs(*title_tldr_abs_en)
         message = "*タイトル*: " + title_ja + "\n"
         message += "*TL;DR*: " + tldr_ja + "\n"

--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,7 @@ def handle_message_events(body):
     text_elements = text_block[0]["elements"][0]["elements"]
     channel = main_event["channel"]
 
-    # take url
+    # retrieve url
     url = ""
     for element in text_elements:
         if element["type"] == "link":
@@ -53,6 +53,7 @@ def handle_message_events(body):
         message += "*TL;DR*: " + tldr_ja + "\n"
         message += "*概要*: " + abstract_ja
 
+        # get side information
         year = data_en["year"]
         venue = data_en["venue"]
         cites = data_en["citationCount"]
@@ -68,6 +69,7 @@ def handle_message_events(body):
         if cites is not None:
             additional_info += "\n*Cited by*: " + str(cites)
 
+        # post message
         app.client.chat_postMessage(
             blocks=[
                 {"type": "header", "text": {"type": "plain_text", "text": data_en["title"]}},

--- a/src/main.py
+++ b/src/main.py
@@ -61,13 +61,6 @@ def handle_message_events(body):
         for item in data_en["authors"]:
             authors += item["name"] + ", "
         authors = authors[:-2]
-        additional_info = "*Authors*: " + authors
-        if venue is not None:
-            additional_info += "\n*Venue*: " + venue
-        if year is not None:
-            additional_info += ", " + str(year)
-        if cites is not None:
-            additional_info += "\n*Cited by*: " + str(cites)
 
         # post message
         app.client.chat_postMessage(

--- a/src/semantic_utils.py
+++ b/src/semantic_utils.py
@@ -28,9 +28,9 @@ def paper_informations(arxiv_url, item=params, tries=20, interval=3):
     while result.status_code != 200:
         if request_time > tries:
             raise TimeoutError("cannot connect to semantic scholar")
-        time.sleep(interval)
-        print(str(request_time) + " request failed")
 
+        print(str(request_time + 1) + "th request for Semantic Scholar is failed. Bot will re-request soon.")
+        time.sleep(interval)
         result = requests.get(endpoint + "ARXIV:" + arxiv_id, params=params)
         request_time += 1
 

--- a/src/semantic_utils.py
+++ b/src/semantic_utils.py
@@ -7,7 +7,7 @@ endpoint = "https://api.semanticscholar.org/graph/v1/paper/"
 params = {"fields": "title,tldr,abstract,authors"}
 
 
-def paper_informations(arxiv_url, item=params):
+def paper_informations(arxiv_url, item=params, tries=20, interval=3):
     """
     take paper informations about arxiv_url
     If you cannot take information within 60 seconds, raise TimeoutError
@@ -26,9 +26,9 @@ def paper_informations(arxiv_url, item=params):
 
     # request some times until take information
     while result.status_code != 200:
-        if request_time > 20:
+        if request_time > tries:
             raise TimeoutError("cannot connect to semantic scholar")
-        time.sleep(3)
+        time.sleep(interval)
         print(str(request_time) + " request failed")
 
         result = requests.get(endpoint + "ARXIV:" + arxiv_id, params=params)


### PR DESCRIPTION
# TL;DR
slackに投げられるメッセージの見た目がよくなりました。

# 概要
- 英語タイトルがヘッダーとして追加されました。
- ヘッダーの下に著者、学会、年度、引用数が表示されます。

# 変更点
1. main.py
-  semantic scholarからより多くの情報をクエリするようになりました。
- post.chatmessage() でblockを引数にとるようになりました。従来の引数のtextは無視されます。
  - blockにいろいろな情報を入れることでヘッダーや追加の情報をメッセージに含めます。
- ついでにarxiv.org以外のurlはスルーするようにしました。
2. semantic_utils.py
- 引数にitem, tries, intervalを設定できるようにしました。
  - item: クエリするパラメータ
  - tries: APIに接続する試行回数
  - interval: 接続試行のインターバル（秒）

# これから
推薦システム系でフィードバックを受け取りたくなった時まで、フロントエンドに関してはこれで十分だと思います。