### PR TITLE
Feature/full text summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.venv/
 */__pycache__/
 .python-version
+paper.pdf
 
 # except for these
 !.gitignore

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 2. このリポジトリを `git clone` する
 4. `pyenv install 3.10.11` する
 4. `poetry config virtualenvs.in-project true` する
-3. `git clone` してきたディレクトリ(以下、そこでのコマンド)で `poetry install` を叩く
+3. `git clone` してきたディレクトリ(以下、そこでのコマンド)で `pyenv local 3.10.11`, `poetry install` を叩く
 5. `pre-commit install` を叩く
 6. **(最重要)** ↑で作られた `paper_summary_bot/.git/hooks/pre-commit` (ファイル)を↓のように編集する
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 ## Setting up virtual environment
 1. `poetry` , `pyenv` を(頑張って)インストールする
 2. このリポジトリを `git clone` する
-4. `pyenv install 3.10.11` する
-4. `poetry config virtualenvs.in-project true` する
-3. `git clone` してきたディレクトリ(以下、そこでのコマンド)で `poetry install` を叩く
-5. `pre-commit install` を叩く
-6. **(最重要)** ↑で作られた `paper_summary_bot/.git/hooks/pre-commit` (ファイル)を↓のように編集する
+3. `pyenv install 3.10.11` する
+4. `pyenv local 3.10.11` する
+5. `poetry config virtualenvs.in-project true` する
+6. `git clone` してきたディレクトリ(以下、そこでのコマンド)で `poetry install` を叩く
+7. `pre-commit install` を叩く
+8. **(最重要)** ↑で作られた `paper_summary_bot/.git/hooks/pre-commit` (ファイル)を↓のように編集する
 
 ```shell
  #!/bin/sh

--- a/src/arxiv_utils.py
+++ b/src/arxiv_utils.py
@@ -1,0 +1,15 @@
+import urllib.request
+
+
+def load_pdf(url):
+    save_path = "paper.pdf"
+    url = url.replace("abs", "pdf")
+    try:
+        pdf = urllib.request.urlopen(url).read()
+        with open(save_path, "wb") as out:
+            out.write(pdf)
+    except urllib.error.HTTPError as err:
+        print(err.code)
+    except urllib.error.URLError as err:
+        print(err.reason)
+    return save_path

--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -11,7 +11,7 @@ from gpt_utils import (
 )
 
 
-def summarize_paper_in_url(url):
+def summarize_paper_in_url(url: str) -> str:
     save_path = load_pdf(url)
     client = create_client()
     thread = call_gpt(client, save_path)

--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -1,21 +1,24 @@
 import asyncio
+import re
 
+from arxiv_utils import load_pdf
 from gpt_utils import (
     call_gpt,
     call_gpt_async,
     create_asyncClient,
     create_client,
-    fulltext_summary_prompt,
     translation_prompt,
 )
 
 
 def summarize_paper_in_url(url):
+    save_path = load_pdf(url)
     client = create_client()
-    prompt = fulltext_summary_prompt(url)
-    print("start")
-    res, tokens = call_gpt(client, prompt)
-    print(res, tokens)
+    thread = call_gpt(client, save_path)
+    thread_messages = client.beta.threads.messages.list(thread.id)
+    response = thread_messages.data[0].content[0].text.value
+    response = re.sub("【.*?source】。", "。", response)
+    return response
 
 
 def split_en(en: str) -> list[str]:

--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -1,10 +1,21 @@
 import asyncio
 
-from gpt_utils import call_gpt_async, create_asyncClient, translation_prompt
+from gpt_utils import (
+    call_gpt,
+    call_gpt_async,
+    create_asyncClient,
+    create_client,
+    fulltext_summary_prompt,
+    translation_prompt,
+)
 
 
 def summarize_paper_in_url(url):
-    pass
+    client = create_client()
+    prompt = fulltext_summary_prompt(url)
+    print("start")
+    res, tokens = call_gpt(client, prompt)
+    print(res, tokens)
 
 
 def split_en(en: str) -> list[str]:

--- a/src/gpt_read.py
+++ b/src/gpt_read.py
@@ -17,7 +17,11 @@ def summarize_paper_in_url(url: str) -> str:
     thread = call_gpt(client, save_path)
     thread_messages = client.beta.threads.messages.list(thread.id)
     response = thread_messages.data[0].content[0].text.value
-    response = re.sub("【.*?source】。", "。", response)
+    response = re.sub(r"【.*?source】", "", response)
+    response = re.sub(r"\s+。", "。", response)
+    response = re.sub(r"・\*", "・ *", response)
+    pattern = re.compile(r"[`\-]{3}(.*?)[`\-]{3}", re.DOTALL)
+    response = pattern.findall(response)[0]
     return response
 
 

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -28,7 +28,7 @@ def create_request(prompt):
 
 
 def translation_prompt(en):
-    return f"日本語に翻訳してください:\n{en}"
+    return f"以下の文章を日本語に翻訳した文のみを出力してください:\n{en}"
 
 
 def summarize_pdf(pdf_url):
@@ -76,13 +76,11 @@ def create_thread(client: OpenAI):
         messages=[
             {
                 "role": "user",
-                "content": "与えられた機械学習に関する論文のPDFを読み、この論文のSummary、ProsとCons、技術的な新規性、実験で何を評価したのかを以下のような形式で日本語で述べてください。\
-                            ### Summary:\
-                            ### Pros:\
-                            ### Cons:\
-                            ### 技術的な新規性:\
-                            ### 実験評価:\
-                            ",
+                "content": "与えられた機械学習に関する論文のPDFを読み、この論文のSummary、ProsとCons、技術的な新規性、\
+                実験評価を日本語でまとめた文章をslackのmrkdwn記法で出力してください。slackのmrkdwn記法の一部は以下の通りです:\
+                太字: *`対象のテキスト`* \
+                斜体: _`対象のテキスト`_ \
+                箇条書き: ・`対象のテキスト`",
             }
         ]
     )

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -1,6 +1,11 @@
 import os
 
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, OpenAI
+
+
+def create_client() -> OpenAI:
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY_KUMA"), timeout=10000, max_retries=3)
+    return client
 
 
 def create_asyncClient() -> AsyncOpenAI:
@@ -26,6 +31,10 @@ def translation_prompt(en):
     return f"日本語に翻訳してください:\n{en}"
 
 
+def fulltext_summary_prompt(url):
+    return f"次の機械学習に関する論文のSummary、Pros.とCons.、技術的な新規性、実験で何を評価したのかを日本語で述べてください:\n{url}"
+
+
 def summarize_pdf(pdf_url):
     # TODO: implement
     pass
@@ -34,6 +43,16 @@ def summarize_pdf(pdf_url):
 async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
     try:
         res = await client.chat.completions.create(**create_request(prompt))
+        tokens = res.usage.total_tokens
+        return res.choices[0].message.content, tokens
+    except BaseException as e:
+        print(f"{e.__class__.__name__}: {e}")
+        raise e
+
+
+def call_gpt(client: OpenAI, prompt: str) -> tuple[str, int]:
+    try:
+        res = client.chat.completions.create(**create_request(prompt))
         tokens = res.usage.total_tokens
         return res.choices[0].message.content, tokens
     except BaseException as e:

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -46,7 +46,7 @@ async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
         raise e
 
 
-def call_gpt(client: OpenAI, save_path) -> tuple[str, int]:
+def call_gpt(client: OpenAI, save_path: str):
     try:
         assistant = create_assistant(client, save_path)
         thread = create_thread(client)
@@ -57,7 +57,7 @@ def call_gpt(client: OpenAI, save_path) -> tuple[str, int]:
         raise e
 
 
-def create_assistant(client, save_path):
+def create_assistant(client: OpenAI, save_path: str):
     vector_store = client.beta.vector_stores.create(name="PDFstore")
     file_streams = [open(save_path, "rb")]
     _ = client.beta.vector_stores.file_batches.upload_and_poll(vector_store_id=vector_store.id, files=file_streams)
@@ -71,7 +71,7 @@ def create_assistant(client, save_path):
     return assistant
 
 
-def create_thread(client):
+def create_thread(client: OpenAI):
     thread = client.beta.threads.create(
         messages=[
             {

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -2,7 +2,6 @@ import os
 
 from openai import AsyncOpenAI, OpenAI
 
-
 def create_client() -> OpenAI:
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY_KUMA"), timeout=10000, max_retries=3)
     return client

--- a/src/gpt_utils.py
+++ b/src/gpt_utils.py
@@ -15,7 +15,7 @@ def create_asyncClient() -> AsyncOpenAI:
 
 def create_request(prompt):
     return {
-        "model": "gpt-4-turbo",
+        "model": "gpt-4o",
         "messages": [
             {
                 "role": "system",
@@ -29,10 +29,6 @@ def create_request(prompt):
 
 def translation_prompt(en):
     return f"日本語に翻訳してください:\n{en}"
-
-
-def fulltext_summary_prompt(url):
-    return f"次の機械学習に関する論文のSummary、Pros.とCons.、技術的な新規性、実験で何を評価したのかを日本語で述べてください:\n{url}"
 
 
 def summarize_pdf(pdf_url):
@@ -50,11 +46,44 @@ async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
         raise e
 
 
-def call_gpt(client: OpenAI, prompt: str) -> tuple[str, int]:
+def call_gpt(client: OpenAI, save_path) -> tuple[str, int]:
     try:
-        res = client.chat.completions.create(**create_request(prompt))
-        tokens = res.usage.total_tokens
-        return res.choices[0].message.content, tokens
+        assistant = create_assistant(client, save_path)
+        thread = create_thread(client)
+        _ = client.beta.threads.runs.create_and_poll(thread_id=thread.id, assistant_id=assistant.id)
+        return thread
     except BaseException as e:
         print(f"{e.__class__.__name__}: {e}")
         raise e
+
+
+def create_assistant(client, save_path):
+    vector_store = client.beta.vector_stores.create(name="PDFstore")
+    file_streams = [open(save_path, "rb")]
+    _ = client.beta.vector_stores.file_batches.upload_and_poll(vector_store_id=vector_store.id, files=file_streams)
+    assistant = client.beta.assistants.create(
+        instructions="You are a machine learning researcher. Summarize the given paper on machine learning.",
+        model="gpt-4o",
+        tools=[{"type": "file_search"}],
+        tool_resources={"file_search": {"vector_store_ids": [vector_store.id]}},
+        temperature=0,
+    )
+    return assistant
+
+
+def create_thread(client):
+    thread = client.beta.threads.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "与えられた機械学習に関する論文のPDFを読み、この論文のSummary、ProsとCons、技術的な新規性、実験で何を評価したのかを以下のような形式で日本語で述べてください。\
+                            ### Summary:\
+                            ### Pros:\
+                            ### Cons:\
+                            ### 技術的な新規性:\
+                            ### 実験評価:\
+                            ",
+            }
+        ]
+    )
+    return thread

--- a/src/main.py
+++ b/src/main.py
@@ -63,6 +63,9 @@ def handle_message_events(body):
             authors += item["name"] + ", "
         authors = authors[:-2]
 
+        # get the full-text summary
+        summary = gpt_read.summarize_paper_in_url(url)
+
         # post message
         semantic = app.client.chat_postMessage(
             blocks=[
@@ -95,7 +98,7 @@ def handle_message_events(body):
             text=message,
             channel=channel,
         )
-        summary = gpt_read.summarize_paper_in_url(url)
+
         app.client.chat_postMessage(
             text=summary,
             channel=channel,

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,7 @@ def handle_message_events(body):
         authors = authors[:-2]
 
         # post message
-        app.client.chat_postMessage(
+        semantic = app.client.chat_postMessage(
             blocks=[
                 {"type": "header", "text": {"type": "plain_text", "text": data_en["title"]}},
                 {
@@ -95,7 +95,13 @@ def handle_message_events(body):
             text=message,
             channel=channel,
         )
-        gpt_read.summarize_paper_in_url(url)
+        summary = gpt_read.summarize_paper_in_url(url)
+        app.client.chat_postMessage(
+            text=summary,
+            channel=channel,
+            thread_ts=semantic["message"]["ts"],
+            blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": summary}}],
+        )
 
 
 # run app bot

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,11 @@ def handle_message_events(body):
         message += "*概要*: " + abstract_ja
 
         # get side information
-        year = data_en["year"]
+        year = ""
+        try:
+            year = data_en["year"]
+        except KeyError as e:
+            year = ""
         venue = data_en["venue"]
         cites = data_en["citationCount"]
         authors = ""

--- a/src/main.py
+++ b/src/main.py
@@ -95,6 +95,7 @@ def handle_message_events(body):
             text=message,
             channel=channel,
         )
+        gpt_read.summarize_paper_in_url(url)
 
 
 # run app bot


### PR DESCRIPTION
# 全文要約の実装

## TL;DR
arxivのURLの論文を全文要約したものをslackに投げる

## 概要
arxivのURLからpdfを取得し、gptに全文要約させた内容をスレッドに投稿する

## 変更点
- READMEにpyenvでのpythonバージョン指定の内容を追加
- `arxiv_utils.py`を作成
    - arxivのリンクからpdfを取得して保存する`load_pdf()`の追加
    - 保存せずにバイナリでそのまま渡したかったが方法が分からない
- `gpt_read.py`に`summarize_paper_in_url()`を追加
    - arxivのURLを受け取ってgptの要約結果を返す
    - 索引のようなものは邪魔なので削除している
- `gpt_utils.py`の変更
    - `create_client()`の追加
        - 全文要約は（一旦）非同期処理なしで行っている
    - モデルをgpt-4oに変更
        - 速くなった（気がする）
    - `create_assistant()`でpdfをgptに投げる
    - `create_thread()`でpromptを与えて要約させる
    - `call_gpt()`で`create_assistant()`,  ‘create_thread()'を使った一連の要約作業を行う
- `main.py`の変更
    - 全文要約の結果をsemantic scholarの翻訳結果と同じスレッドに投げる

## これからやること
- ~要約結果をmarkdown記法のまま投げているが、見にくいのでslackのmrkdwn記法に変換したい~
    - ~commonmarkslackというライブラリでできるが重いらしい~
    - gptに要約と同時にmrkdwn記法で出力させたいがなかなかうまくいかず一旦諦めた
        - ↑できました
- 例外処理をほとんどしていないのでしたほうがいいかも
- pdfをいちいち保存しているのでバイナリで読み込んだものをそのまま渡せれば嬉しい